### PR TITLE
Fix issue that cannot lgtm for lgtm.in own certificate authority

### DIFF
--- a/bots/lgtm.js
+++ b/bots/lgtm.js
@@ -11,6 +11,7 @@ module.exports = {
         "Cache-Control" : "no-cache",
         "Accept":"application/json"
       },
+      strictSSL: false,
     }, ( err, response, body ) => {
       const message = `[![Looks good to ${ req.body[ "user_name" ] }!](${ JSON.parse( body ).imageUrl } "Looks good to ${ req.body[ "user_name" ] }!")](${ JSON.parse( body ).imageUrl })`;
       console.log( message );


### PR DESCRIPTION
LGTM.in がオレオレ証明書を使うようになって接続できなくなっていたので `strictSSL` を無効にした。